### PR TITLE
Another way to open Sidecar

### DIFF
--- a/Connect Sidecar - Monterey - Way 2
+++ b/Connect Sidecar - Monterey - Way 2
@@ -1,0 +1,17 @@
+beep 1
+activate application "SystemUIServer"
+tell application "System Preferences"
+	activate
+	set the current pane to pane id "com.apple.preference.Displays"
+	delay 3
+	tell application "System Events"
+		tell process "System Preferences"
+			tell window "Displays"
+				click pop up button 1
+				click menu item 2 of menu 1 of pop up button 1
+			end tell
+		end tell
+	end tell
+	quit
+end tell
+say "Sidecar"


### PR DESCRIPTION
When exiting Sidecar in Control Center. The checkbox is not selected. But Sidecar is actually still connected. This is a probability. I guess it is a system bug.
Here is another way to open Sidecar. Go to display settings in system settings to start or exit Sidecar. It is a simple code and tested on Monterey without problems.