### PR TITLE
able to use in any language by setting variables

### DIFF
--- a/Connect Sidecar - Monterey.applescript
+++ b/Connect Sidecar - Monterey.applescript
@@ -2,21 +2,25 @@ use AppleScript version "2.4" -- Yosemite (10.10) or later
 use scripting additions
 
 set deviceName to "My iPad" -- Change this to the name of your iPad.
+set controlCenterName to "Control Center" -- Change this according to your language
+set connectToSidecarName to "Connect to Sidecar" -- Change this according to your language
+set disconnectSidecarName to "Disconnect" -- Change this according to your language
 
 tell application "System Events"
 	tell its application process "ControlCenter"
 		-- Click the Control Center menu.
-		click menu bar item "Control Center" of menu bar 1
+		click menu bar item controlCenterName of menu bar 1
 		
 		-- Give the window time to draw.
 		delay 1
 		
 		-- Get all of the checkboxes in the Control Center menu.
-		set ccCheckboxes to name of (every checkbox of window "Control Center")
+		set ccCheckboxes to name of (every checkbox of window controlCenterName)
 		
-		if ccCheckboxes contains "Connect to Sidecar" then
+		
+		if ccCheckboxes contains connectToSidecarName then
 			-- If one of the checkboxes is named "Connect to Sidecar," click that checkbox.
-			set sidecarToggle to checkbox "Connect to Sidecar" of window "Control Center"
+			set sidecarToggle to checkbox connectToSidecarName of window controlCenterName
 			click sidecarToggle
 			
 			-- This opens a secondary window that contains the button to actually connect to Sidecar. Give the window time to draw.
@@ -24,7 +28,7 @@ tell application "System Events"
 			
 			-- In masOS Monterey, the Sidecar device toggle (checkbox) is inside of a scroll area.
 			-- Rather than assume that it's in scroll area 1, get all of the scroll areas, loop through them, and find the device toggle.
-			set scrollAreas to (every scroll area of window "Control Center")
+			set scrollAreas to (every scroll area of window controlCenterName)
 			set saCounter to 1
 			set displayCheckboxes to ""
 			
@@ -42,16 +46,16 @@ tell application "System Events"
 			
 			if displayCheckboxes contains deviceName then
 				-- If we found the a checkbox with the iPad's name, `saCounter` tells us which scroll area contains the Sidecar toggle.
-				set deviceToggle to checkbox deviceName of scroll area saCounter of window "Control Center"
+				set deviceToggle to checkbox deviceName of scroll area saCounter of window controlCenterName
 				
 				-- Click the toggle to connect Sidecar.
 				click deviceToggle
 				
 				-- Click the Control Center menu to close the secondary menu and return to the main menu.
-				click menu bar item "Control Center" of menu bar 1
+				click menu bar item controlCenterName of menu bar 1
 				
 				-- Click the Control Center menu again to close the main menu.
-				click menu bar item "Control Center" of menu bar 1
+				click menu bar item controlCenterName of menu bar 1
 			else
 				-- Sidecar is available, but no devices with deviceName were found.
 				display dialog "The device " & deviceName & " can't be found. Please verify the name of your iPad and update the `deviceName` variable if necessary."
@@ -61,7 +65,7 @@ tell application "System Events"
 			set isConnected to false
 			repeat with cb in ccCheckboxes
 				-- Loop through the checkboxes and determine if Sidecar is already connected.
-				if cb contains "Disconnect" then
+				if cb contains disconnectSidecarName then
 					-- If one of the checkboxes has "Disconnect" in its name, Sidecar is already connected.
 					-- Break out of the loop.
 					set isConnected to true
@@ -71,11 +75,11 @@ tell application "System Events"
 			
 			if isConnected is equal to true then
 				-- Click the checkbox to disconnect Sidecar.
-				set sidecarToggle to ((checkbox 1 of window "Control Center") whose name contains "Disconnect")
+				set sidecarToggle to ((checkbox 1 of window controlCenterName) whose name contains disconnectSidecarName)
 				click sidecarToggle
 				
 				-- Click the Control Center menu again to close the main menu.
-				click menu bar item "Control Center" of menu bar 1
+				click menu bar item controlCenterName of menu bar 1
 			else
 				-- Sidecar isn't connected, and no devices are available to connect to. Show an error message.
 				display dialog "No Sidecar devices are in range."


### PR DESCRIPTION
Thank you for providing a great script. It was very helpful.

By using variables,  users can change script code according to the language they are using.

For example, in the case of Japanese, it will be as follows.
`"Control Center"` -> `"コントロールセンター"`
`"Connect to Sidecar"` -> `"Sidecarに接続"`
`"Disconnect"` -> `"接続解除"`

In other languages, changing the value of the variables will make the script work.

associated with #5 